### PR TITLE
Issue for checking out the gh-pages branch

### DIFF
--- a/documenter/deploy.py
+++ b/documenter/deploy.py
@@ -196,7 +196,7 @@ class Documentation(object):
             log_and_execute(["git", "remote", "add", "local_upstream", self.local_upstream])
 
         log_and_execute(["git", "remote", "add", "upstream", self.upstream])
-        log_and_execute(["git", "fetch", "upstream", self.doc_branch])
+        log_and_execute(["git", "fetch", "upstream"])
         try:
             log_and_execute(["git", "checkout", "-b", self.doc_branch, "upstream/" + self.doc_branch])
         except RuntimeError:

--- a/documenter/deploy.py
+++ b/documenter/deploy.py
@@ -203,7 +203,7 @@ class Documentation(object):
             try:
                 log_and_execute(["git", "checkout",
                                  "--orphan", self.doc_branch])
-                log_and_execute(["git", "rm", "--cached", "-r", "."])
+                #log_and_execute(["git", "rm", "--cached", "-r", "."])
             except:
                 raise RuntimeError("could not checkout remote branch.")
 

--- a/documenter/deploy.py
+++ b/documenter/deploy.py
@@ -203,7 +203,7 @@ class Documentation(object):
             try:
                 log_and_execute(["git", "checkout",
                                  "--orphan", self.doc_branch])
-                #log_and_execute(["git", "rm", "--cached", "-r", "."])
+                log_and_execute(["git", "rm", "--cached", "-r", "."])
             except:
                 raise RuntimeError("could not checkout remote branch.")
 


### PR DESCRIPTION
Instead of `git fetch upstream gh-pages`, it should be `git fetch upstream` only. The first variant fetches and creates the `gh-pages` directly as well, which conflicts with the subsequent commands.

All branches will be fetched, but that should be fine.